### PR TITLE
Raise a more clear error when a Pardot account is disabled

### DIFF
--- a/lib/pardot/error.rb
+++ b/lib/pardot/error.rb
@@ -2,6 +2,7 @@ module Pardot
   class Error < StandardError; end
   class NetError < Error; end
   class ExpiredApiKeyError < Error; end
+  class AccountDisabledError < Error; end
 
   class ResponseError < Error
     def initialize(res)

--- a/lib/pardot/http.rb
+++ b/lib/pardot/http.rb
@@ -1,63 +1,68 @@
 module Pardot
   module Http
-    
+
     def get object, path, params = {}, num_retries = 0
       smooth_params object, params
       full_path = fullpath object, path
       check_response self.class.get(full_path, :query => params)
-      
+
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :get, object, path, params, num_retries, e
-      
+
     rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error, MultiXml::ParseError => e
       raise Pardot::NetError.new(e)
     end
-    
+
     def post object, path, params = {}, num_retries = 0
       smooth_params object, params
       full_path = fullpath object, path
       check_response self.class.post(full_path, :query => params)
-      
+
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :post, object, path, params, num_retries, e
-      
+
     rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error, MultiXml::ParseError => e
       raise Pardot::NetError.new(e)
     end
-    
+
     protected
-    
+
     def handle_expired_api_key method, object, path, params, num_retries, e
       raise e unless num_retries == 0
-      
+
       reauthenticate
-      
+
       send(method, object, path, params, 1)
     end
-    
+
     def smooth_params object, params
       return if object == "login"
-      
+
       authenticate unless authenticated?
       params.merge! :user_key => @user_key, :api_key => @api_key, :format => @format
     end
-    
+
     def check_response http_response
+      # Pardot unfortunately returns 200 with a plaintext message, which causes XML parsing to fail
+      if http_response.body.start_with? 'Your account has been disabled'
+        raise AccountDisabledError.new http_response.body
+      end
+
       rsp = http_response["rsp"]
-      
+
       error = rsp["err"] if rsp
       error ||= "Unknown Failure: #{rsp.inspect}" if rsp && rsp["stat"] == "fail"
       content = error['__content__'] if error.is_a?(Hash)
-      
+
       if [error, content].include?("Invalid API key or user key") && @api_key
         raise ExpiredApiKeyError.new @api_key
       end
-      
+
       raise ResponseError.new error if error
-      
+
       rsp
     end
-    
+
     def fullpath object, path
       full = File.join("/api", object, "version", @version.to_s)
       unless path.nil?
@@ -65,6 +70,6 @@ module Pardot
       end
       full
     end
-    
+
   end
 end


### PR DESCRIPTION
The Pardot API unfortunately returns a 200 OK response with a
plaintext message, even though the reqeust asked for XML which
causes nogokiri's XML parsing to fail with an obtuse error
(e.g. #<MultiXml::ParseError: 1:1: FATAL: Start tag expected, '<' not found>)

This change preemptively checks the raw response body for the
'account disabled' message so we can raise a more transparent error