### PR TITLE
[ALT-624] W-5653730: Change to pass auth parameters in body.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,22 @@
 PATH
   remote: .
   specs:
-    ruby-pardot (1.1.0)
-      crack
-      httparty
+    ruby-pardot (1.2.0)
+      crack (= 0.4.3)
+      httparty (= 0.13.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    crack (0.4.2)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.1.2)
     fakeweb (1.3.0)
     httparty (0.13.1)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    json (1.8.3)
-    multi_xml (0.5.5)
+    json (1.8.6)
+    multi_xml (0.6.0)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
@@ -37,4 +37,4 @@ DEPENDENCIES
   ruby-pardot!
 
 BUNDLED WITH
-   1.11.2
+   2.0.1

--- a/lib/pardot/authentication.rb
+++ b/lib/pardot/authentication.rb
@@ -2,7 +2,7 @@ module Pardot
   module Authentication
     
     def authenticate
-      resp = post "login", nil, :email => @email, :password => @password, :user_key => @user_key
+      resp = post "login", nil, nil, nil, :email => @email, :password => @password, :user_key => @user_key
       update_version(resp["version"]) if resp && resp["version"]
       @api_key = resp && resp["api_key"]
     end

--- a/lib/pardot/http.rb
+++ b/lib/pardot/http.rb
@@ -13,10 +13,10 @@ module Pardot
       raise Pardot::NetError.new(e)
     end
 
-    def post object, path, params = {}, num_retries = 0
+    def post object, path, params = {}, num_retries = 0, bodyParams = {}
       smooth_params object, params
       full_path = fullpath object, path
-      check_response self.class.post(full_path, :query => params)
+      check_response self.class.post(full_path, :query => params, :body => bodyParams)
 
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :post, object, path, params, num_retries, e

--- a/lib/pardot/version.rb
+++ b/lib/pardot/version.rb
@@ -1,3 +1,3 @@
 module Pardot
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ruby-pardot"
 
-  s.add_dependency "crack"
-  s.add_dependency "httparty"
+  s.add_dependency "crack", "0.4.3"
+  s.add_dependency "httparty", "0.13.1"
 
   s.add_development_dependency "bundler", ">= 1.10"
   s.add_development_dependency "rspec"

--- a/spec/pardot/authentication_spec.rb
+++ b/spec/pardot/authentication_spec.rb
@@ -11,12 +11,16 @@ describe Pardot::Authentication do
     before do
       @client = create_client
       
-      fake_post "/api/login/version/3?email=user%40test.com&password=foo&user_key=bar",
+      fake_post "/api/login/version/3",
                 %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">\n   <api_key>my_api_key</api_key>\n</rsp>\n)
     end
     
     def authenticate
       @client.authenticate
+    end
+
+    def verifyBody
+      FakeWeb.last_request.body.should == 'email=user%40test.com&password=foo&user_key=bar'
     end
     
     it "should return the api key" do
@@ -26,16 +30,19 @@ describe Pardot::Authentication do
     it "should set the api key" do
       authenticate
       @client.api_key.should == "my_api_key"
+      verifyBody
     end
     
     it "should make authenticated? true" do
       authenticate
       @client.authenticated?.should == true
+      verifyBody
     end
 
     it "should use version 3" do
       authenticate
       @client.version.to_i.should == 3
+      verifyBody
     end
     
   end
@@ -45,12 +52,16 @@ describe Pardot::Authentication do
     before do
       @client = create_client
       
-      fake_post "/api/login/version/3?email=user%40test.com&password=foo&user_key=bar",
+      fake_post "/api/login/version/3",
                 %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">\n   <api_key>my_api_key</api_key>\n<version>4</version>\n</rsp>\n)
     end
     
     def authenticate
       @client.authenticate
+    end
+
+    def verifyBody
+      FakeWeb.last_request.body.should == 'email=user%40test.com&password=foo&user_key=bar'
     end
     
     it "should return the api key" do
@@ -60,16 +71,19 @@ describe Pardot::Authentication do
     it "should set the api key" do
       authenticate
       @client.api_key.should == "my_api_key"
+      verifyBody
     end
     
     it "should make authenticated? true" do
       authenticate
       @client.authenticated?.should == true
+      verifyBody
     end
 
     it "should use version 4" do
       authenticate
       @client.version.to_i.should == 4
+      verifyBody
     end
     
   end


### PR DESCRIPTION
Passing parameters using query string to auth is deprecated.

![over](https://user-images.githubusercontent.com/4258418/53811734-05334a80-3f28-11e9-87ed-854df872a964.gif)
