### PR TITLE
Stop using deprecated AUth

### DIFF
--- a/lib/pardot/http.rb
+++ b/lib/pardot/http.rb
@@ -2,9 +2,10 @@ module Pardot
   module Http
 
     def get object, path, params = {}, num_retries = 0
-      smooth_params object, params
+      headers = {}
+      smooth_params_and_headers object, params, headers
       full_path = fullpath object, path
-      check_response self.class.get(full_path, :query => params)
+      check_response self.class.get(full_path, :query => params, :headers => headers)
 
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :get, object, path, params, num_retries, e
@@ -14,9 +15,10 @@ module Pardot
     end
 
     def post object, path, params = {}, num_retries = 0, bodyParams = {}
-      smooth_params object, params
+      headers = {}
+      smooth_params_and_headers object, params, headers
       full_path = fullpath object, path
-      check_response self.class.post(full_path, :query => params, :body => bodyParams)
+      check_response self.class.post(full_path, :query => params, :body => bodyParams, :headers => headers)
 
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :post, object, path, params, num_retries, e
@@ -35,11 +37,12 @@ module Pardot
       send(method, object, path, params, 1)
     end
 
-    def smooth_params object, params
+    def smooth_params_and_headers object, params, headers
       return if object == "login"
 
       authenticate unless authenticated?
-      params.merge! :user_key => @user_key, :api_key => @api_key, :format => @format
+      params.merge! :format => @format
+      headers.merge! 'Authorization' => "Pardot api_key=#{@api_key}, user_key=#{@user_key}"
     end
 
     def check_response http_response

--- a/lib/pardot/version.rb
+++ b/lib/pardot/version.rb
@@ -1,3 +1,3 @@
 module Pardot
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/spec/pardot/http_spec.rb
+++ b/spec/pardot/http_spec.rb
@@ -18,7 +18,7 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_get "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_get "/api/foo/version/3/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { get }.should raise_error(Pardot::ResponseError)
@@ -31,7 +31,7 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_get "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_get "/api/foo/version/3/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
@@ -47,7 +47,7 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_post "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_post "/api/foo/version/3/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { post }.should raise_error(Pardot::ResponseError)
@@ -60,7 +60,7 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_post "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_post "/api/foo/version/3/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
@@ -77,7 +77,7 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_get "/api/foo/version/4/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_get "/api/foo/version/4/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { get }.should raise_error(Pardot::ResponseError)
@@ -90,7 +90,7 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_get "/api/foo/version/4/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_get "/api/foo/version/4/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
@@ -107,7 +107,7 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_post "/api/foo/version/4/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_post "/api/foo/version/4/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { post }.should raise_error(Pardot::ResponseError)
@@ -120,7 +120,7 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_post "/api/foo/version/4/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_post "/api/foo/version/4/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)


### PR DESCRIPTION
Properly set Authorization header for all requests that are not login requests.

http://developer.pardot.com/#using-the-api